### PR TITLE
Remove wavefront map and PSF plots

### DIFF
--- a/wfssrv/templates/wfs.html
+++ b/wfssrv/templates/wfs.html
@@ -451,9 +451,6 @@
                     <a class="nav-link" id='bar-tab' href="#zerns" aria-controls="zerns" role="tab" data-toggle="tab" aria-selected="false">RMS Wavefront Errors</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" id='wave-tab' href="#wavefront" aria-controls="wavefront" role="tab" data-toggle="tab" aria-selected="false">Wavefront Map/PSF</a>
-                </li>
-                <li class="nav-item">
                     <a class="nav-link" id='cell-tab' href="#cell" aria-controls="cell" role="tab" data-toggle="tab" aria-selected="false">Cell Forces</a>
                 </li>
             </ul>
@@ -495,20 +492,6 @@
                             <tr>
                                 <td colspan="2" align="center">
                                     <div id="barchart"></div>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                <div role="tabpanel" class="tab-pane fade" id="wavefront" aria-labelledby="wave-tab">
-                    <table class="table table-striped">
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <div id="wavefront"></div>
-                                </td>
-                                <td>
-                                    <div id="psf"></div>
                                 </td>
                             </tr>
                         </tbody>


### PR DESCRIPTION
These plots, the PSF one especially, were a drag on performance during normal operations and not very heavily used. This PR removes them for now. Faster, more efficient methods of building the PSF plot will be explored. The label for the RMS bar chart plot was also tweaked. There was a bug in converting from ``nm`` of RMS to arcsec and this has been replaced with expressing the RMS in waves at 550 nm.