### PR TITLE
Add support for running and testing using pixi

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ pip-wheel-metadata/
 # Mac OSX
 .DS_Store
 coverage.xml
+# pixi environments
+.pixi
+wfs.log
+pixi.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,3 +109,21 @@ filterwarnings = [
             # Don't complain about IPython completion helper
             "def _ipython_key_completions_",
         ]
+
+[tool.pixi.workspace]
+channels = ["conda-forge"]
+platforms = ["osx-arm64", "linux-64"]
+
+[tool.pixi.pypi-dependencies]
+wfssrv = { path = ".", editable = true }
+
+[tool.pixi.environments]
+default = { solve-group = "default" }
+docs = { features = ["docs"], solve-group = "default" }
+test = { features = ["test"], solve-group = "default" }
+
+[tool.pixi.tasks]
+wfssrv = "wfssrv"
+
+[tool.pixi.feature.test.tasks]
+test = "pytest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ wfssrv = { path = ".", editable = true }
 
 [tool.pixi.target.linux-64.dependencies]
 mkl = "*"
+mkl-service = "*"
 
 [tool.pixi.environments]
 default = { solve-group = "default" }
@@ -130,3 +131,6 @@ wfssrv = "wfssrv"
 
 [tool.pixi.feature.test.tasks]
 test = "pytest"
+
+[tool.pixi.dependencies]
+matplotlib = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ requires = [
 build-backend = 'setuptools.build_meta'
 
 [tool.pytest.ini_options]
-minversion = 7.0
+minversion = "7.0"
 testpaths = [
     "wfssrv/tests",
 ]
@@ -116,6 +116,9 @@ platforms = ["osx-arm64", "linux-64"]
 
 [tool.pixi.pypi-dependencies]
 wfssrv = { path = ".", editable = true }
+
+[tool.pixi.target.linux-64.dependencies]
+mkl = "*"
 
 [tool.pixi.environments]
 default = { solve-group = "default" }


### PR DESCRIPTION
This PR adds support for running and testing this package using `pixi`. This keeps all the appropriate dependencies within the directory where the code is checked out and provides better control over them. So far `pixi run test` and `pixi run wfssrv` are implemented. The former tests that the dependencies and package all work together and run, the latter runs the actual WFS analysis server.