### PR TITLE
Add javascript tests for the template control logic

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -1,0 +1,35 @@
+# Tests for the interactive javascript embedded in the wfssrv templates.
+#
+# This is kept separate from the python workflow because that one delegates to
+# the OpenAstronomy re-usable tox workflow, which has no place to hang a node
+# job. The templates have no build step; node is only ever needed to run these
+# tests.
+
+name: JS Tests
+
+# Match the python workflow: only master and tags on push, everything else is
+# covered by the pull_request trigger.
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+
+jobs:
+  test:
+    name: node ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22', '24']
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ wfs.log
 pixi.lock
 
 .codegraph/
+
+node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,13 @@ The test suite is minimal — it just instantiates `WFSsrv()`. Because the const
 
 Python 3.13 is the minimum (`mmtwfs` requires >= 3.13); `tox.ini` defines `py313` and `py314` envs only. CI (`.github/workflows/wfssrv-tests.yml`) runs `py{313,314}-{cov,astropydev,numpydev}` plus `build_docs`, `linkcheck`, and `codestyle`.
 
+The browser-side javascript in the templates is tested separately, with node's built-in test runner:
+```bash
+npm install   # once; jsdom is the only dependency
+npm test      # runs wfssrv/tests/js/*.test.js
+```
+These tests read the inline `<script>` block out of `wfs.html` and `cwfs.html` and exercise it under jsdom, so they track what the server actually serves rather than a copy. The DOM fixtures in `wfssrv/tests/js/harness.js` are maintained by hand and guarded by a test asserting that every element the template script reaches for is present — if you add or rename a control, update the fixture. Node is only needed to run these tests; the served page has no build step. CI runs them from `.github/workflows/js-tests.yml` on node 22 and 24.
+
 ### Code style
 ```bash
 flake8 wfssrv --max-line-length=135   # lint (max line length is 135)
@@ -37,6 +44,16 @@ black wfssrv                           # format
 tox -e build_docs   # build Sphinx docs
 tox -e linkcheck    # check doc links
 ```
+
+### Deployment
+
+The summit installs from GitHub, into the `mmtwfs` conda environment used there:
+```bash
+pip install git+https://github.com/MMTObservatory/wfssrv#egg=wfssrv --upgrade
+```
+Then restart the server, and have the telescope operator reload their browser page to pick up template changes.
+
+This installs from `master`, and the summit does not run from a working checkout — a fix is not deployed until it is pushed to `master`. Note that the templates ship as package data, so front-end changes reach the summit through this same install, not through a file copy.
 
 ## Architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,641 @@
+{
+    "name": "wfssrv-templates",
+    "version": "0.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "wfssrv-templates",
+            "version": "0.0.0",
+            "license": "BSD-3-Clause",
+            "devDependencies": {
+                "jsdom": "^28.0.0"
+            }
+        },
+        "node_modules/@acemir/cssom": {
+            "version": "0.9.31",
+            "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+            "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@csstools/css-calc": "^3.2.0",
+                "@csstools/css-color-parser": "^4.1.0",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "6.8.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+            "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.1.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.2.6"
+            }
+        },
+        "node_modules/@asamuzakjp/generational-cache": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+            "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+            "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+            "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+            "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^6.1.1",
+                "@csstools/css-calc": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+            "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "peerDependencies": {
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@exodus/bytes": {
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+            "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
+            }
+        },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/cssstyle": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+            "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^5.0.1",
+                "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+                "css-tree": "^3.1.0",
+                "lru-cache": "^11.2.6"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/data-urls": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jsdom": {
+            "version": "28.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+            "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@acemir/cssom": "^0.9.31",
+                "@asamuzakjp/dom-selector": "^6.8.1",
+                "@bramus/specificity": "^2.4.2",
+                "@exodus/bytes": "^1.11.0",
+                "cssstyle": "^6.0.1",
+                "data-urls": "^7.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "parse5": "^8.0.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.0",
+                "undici": "^7.21.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tldts": {
+            "version": "7.4.11",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+            "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.4.11"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.4.11",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+            "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tough-cookie": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+            "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/undici": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
+            }
+        },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "wfssrv-templates",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Tests for the interactive javascript in the wfssrv templates. Not published or installed at runtime; the served page has no build step.",
+    "license": "BSD-3-Clause",
+    "scripts": {
+        "test": "node --test \"wfssrv/tests/js/*.test.js\""
+    },
+    "devDependencies": {
+        "jsdom": "^28.0.0"
+    }
+}

--- a/wfssrv/tests/js/controls.test.js
+++ b/wfssrv/tests/js/controls.test.js
@@ -1,0 +1,144 @@
+"use strict";
+
+// Tests for the control logic in the wfssrv templates, in particular the
+// continuous WFS loop. See harness.js: the javascript is read out of the
+// templates, so these tests track what the server actually serves.
+
+const test = require("node:test");
+const assert = require("node:assert");
+const { mount, referencedIds } = require("./harness.js");
+
+// a new frame has landed on top of the one currently loaded
+const NEW_FRAME = ["wfs_0002.fits", "wfs_0001.fits"];
+
+function startContinuous(page, { connect = false, turbo = false } = {}) {
+    page.el("connect").checked = connect;
+    page.el("turbo").checked = turbo;
+    page.el("datafile").value = "wfs_0001.fits";
+    page.el("continuous").click();
+}
+
+test("continuous mode analyzes a new frame even though the controls are disabled", async () => {
+    const page = mount("wfs.html", { files: NEW_FRAME });
+    startContinuous(page);
+    await page.advance(1500);
+
+    // the loop disables the controls to keep the operator's hands off them, so
+    // it must not rely on the buttons being clickable. this is the regression
+    // that broke continuous mode when jquery was removed.
+    assert.equal(page.el("analyze").disabled, true, "analyze should be disabled during continuous");
+    assert.equal(page.count("analyze"), 1, "a new frame should have been analyzed");
+    assert.match(page.urls("analyze")[0], /fitsfile=\/data\/wfs_0002\.fits/);
+});
+
+test("continuous mode applies focus, coma and m1 corrections when connected", async () => {
+    const page = mount("wfs.html", { files: NEW_FRAME });
+    startContinuous(page, { connect: true });
+    await page.advance(1500);
+
+    assert.equal(page.count("focuscorrect"), 1);
+    assert.equal(page.count("comacorrect"), 1);
+    assert.equal(page.count("m1correct"), 1);
+});
+
+test("continuous mode sends no corrections when not connected", async () => {
+    const page = mount("wfs.html", { files: NEW_FRAME });
+    startContinuous(page, { connect: false });
+    await page.advance(1500);
+
+    assert.equal(page.count("analyze"), 1, "it should still analyze");
+    assert.equal(page.count("focuscorrect") + page.count("comacorrect") + page.count("m1correct"), 0);
+});
+
+test("continuous mode keeps polling but does not re-analyze the same frame", async () => {
+    const page = mount("wfs.html", { files: NEW_FRAME });
+    startContinuous(page);
+    await page.advance(20000);
+
+    assert.ok(page.count("files") > 2, "the loop should keep polling for new frames");
+    assert.equal(page.count("analyze"), 1, "the same frame should only be analyzed once");
+});
+
+test("continuous mode picks up each new frame as it arrives", async () => {
+    const page = mount("wfs.html", { files: NEW_FRAME });
+    startContinuous(page);
+    await page.advance(10000);
+    assert.equal(page.count("analyze"), 1);
+
+    page.setFiles(["wfs_0003.fits", ...NEW_FRAME]);
+    await page.advance(10000);
+
+    assert.equal(page.count("analyze"), 2);
+    assert.match(page.urls("analyze")[1], /fitsfile=\/data\/wfs_0003\.fits/);
+});
+
+test("the MMIRS layout has no mode selector and omits mode from the analyze url", async () => {
+    const page = mount("wfs.html", { files: NEW_FRAME, mode: false });
+    assert.equal(page.el("mode"), null, "MMIRS renders no mode selector");
+    startContinuous(page);
+    await page.advance(1500);
+
+    const url = page.urls("analyze")[0];
+    assert.doesNotMatch(url, /mode=/);
+    assert.match(url, /fitsfile=\/data\/wfs_0002\.fits/);
+});
+
+test("a layout with a mode selector passes the mode through", async () => {
+    const page = mount("wfs.html", { files: NEW_FRAME });
+    startContinuous(page);
+    await page.advance(1500);
+
+    assert.match(page.urls("analyze")[0], /mode=blue/);
+});
+
+test("starting continuous mode backs the gains off, unless turbo is set", async () => {
+    const page = mount("wfs.html", { files: NEW_FRAME });
+    startContinuous(page);
+    assert.equal(Number(page.el("m1gain").value), 0.2);
+    assert.equal(Number(page.el("m2gain").value), 0.5);
+
+    const turbo = mount("wfs.html", { files: NEW_FRAME });
+    startContinuous(turbo, { turbo: true });
+    assert.equal(Number(turbo.el("m1gain").value), 0.5);
+    assert.equal(Number(turbo.el("m2gain").value), 1.0);
+});
+
+test("stopping continuous mode restores the gains and re-enables the controls", async () => {
+    const page = mount("wfs.html", { files: NEW_FRAME });
+    startContinuous(page);
+    await page.advance(1500);
+
+    page.el("continuous").click();
+    await page.settle();
+
+    assert.equal(Number(page.el("m1gain").value), 0.5);
+    assert.equal(Number(page.el("m2gain").value), 1.0);
+    assert.equal(page.el("analyze").disabled, false);
+    assert.equal(page.count("m1gain"), 2, "gains should be pushed on start and on stop");
+
+    const analyses = page.count("analyze");
+    await page.advance(20000);
+    assert.equal(page.count("analyze"), analyses, "the loop should be stopped");
+});
+
+test("the cwfs latest button loads the two newest frames and analyzes them", async () => {
+    const page = mount("cwfs.html", { files: ["cwfs_0002.fits", "cwfs_0001.fits"] });
+    page.el("latest").click();
+    await page.settle();
+
+    assert.equal(page.el("datafile1").value, "cwfs_0002.fits");
+    assert.equal(page.el("datafile2").value, "cwfs_0001.fits");
+    assert.equal(page.count("analyze"), 1);
+});
+
+// The fixtures in harness.js are maintained by hand. This keeps them honest: if
+// a template grows or renames a control, this fails and tells you to update the
+// fixture rather than quietly testing less than it appears to.
+for (const template of ["wfs.html", "cwfs.html"]) {
+    test(`the ${template} fixture provides every element the template uses`, () => {
+        const page = mount(template);
+        for (const id of referencedIds(template)) {
+            assert.ok(page.el(id), `${template}: fixture is missing #${id}`);
+        }
+    });
+}

--- a/wfssrv/tests/js/harness.js
+++ b/wfssrv/tests/js/harness.js
@@ -1,0 +1,137 @@
+"use strict";
+
+// Test harness for the interactive javascript embedded in the wfssrv templates.
+//
+// The javascript under test is pulled straight out of the .html template rather
+// than copied here, so these tests always exercise the code the server actually
+// serves. A copy would drift and quietly stop catching regressions.
+
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+const TEMPLATE_DIR = path.join(__dirname, "..", "..", "templates");
+
+// the control logic lives in the one inline <script> block that defines
+// controlButtons. the other blocks are figure/websocket plumbing.
+function scriptBlock(template) {
+    const src = fs.readFileSync(path.join(TEMPLATE_DIR, template), "utf8");
+    const blocks = [...src.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+    const found = blocks.filter((b) => b.includes("controlButtons"));
+    if (found.length !== 1) {
+        throw new Error(`${template}: expected one control script block, found ${found.length}`);
+    }
+    return found[0];
+}
+
+// every element id the template's control script reaches for
+function referencedIds(template) {
+    const matches = scriptBlock(template).matchAll(/getElementById\(['"]([^'"]+)['"]\)/g);
+    return new Set([...matches].map((m) => m[1]));
+}
+
+const button = (id) => `<button type="button" id="${id}"></button>`;
+const offButton = (id) => `<button type="button" id="${id}" disabled="disabled"></button>`;
+const check = (id) => `<input type="checkbox" id="${id}">`;
+
+// Minimal stand-ins for the control markup. Kept by hand rather than generated
+// so that a template that grows a new control trips the fixture guard in
+// controls.test.js instead of silently going untested.
+const FIXTURES = {
+    // the MMIRS page renders no mode selector, so the analyze url is built
+    // differently there. mode: false reproduces that layout.
+    "wfs.html": ({ mode = true } = {}) => `
+        ${["focuscorrect", "comacorrect", "m1correct", "recenter"].map(offButton).join("")}
+        ${["clear", "clearm1", "clearm2", "setgains", "analyze", "latest", "continuous"].map(button).join("")}
+        <input id="m1gain" value="0.5">
+        <input id="m2gain" value="1.0">
+        ${["turbo", "connect", "spher"].map(check).join("")}
+        <input id="datafile" value="">
+        ${mode ? '<select id="mode"><option value="blue" selected></option></select>' : ""}
+        <span id="datadir">/data/</span>
+        <span id="zernikes"></span>`,
+    "cwfs.html": () => `
+        ${["focuscorrect", "comacorrect", "m1correct", "recenter"].map(offButton).join("")}
+        ${["clear", "clearm1", "clearm2", "setgains", "analyze", "latest"].map(button).join("")}
+        <input id="m1gain" value="0.5">
+        <input id="m2gain" value="1.0">
+        ${["connect", "spher"].map(check).join("")}
+        <input id="datafile1" value="">
+        <input id="datafile2" value="">
+        <span id="datadir">/data/</span>
+        <span id="zernikes"></span>`,
+};
+
+// let queued promise callbacks run. several rounds, because the handlers chain
+// fetch promises a few deep (poll -> analyze -> corrections).
+async function settle(rounds = 5) {
+    for (let i = 0; i < rounds; i++) {
+        await new Promise((resolve) => setImmediate(resolve));
+    }
+}
+
+function mount(template, opts = {}) {
+    const dom = new JSDOM(`<body>${FIXTURES[template](opts)}</body>`, { runScripts: "outside-only" });
+    const win = dom.window;
+    const doc = win.document;
+
+    const calls = [];
+    let files = opts.files || [];
+
+    win.alert = () => {};
+    win.fetch = (url, init) => {
+        const u = String(url);
+        calls.push({ url: u, path: u.split("?")[0], method: (init && init.method) || "GET" });
+        const body = u.startsWith("files") ? JSON.stringify(files) : JSON.stringify("Z04 = 100 nm");
+        return Promise.resolve({
+            text: () => Promise.resolve(body),
+            json: () => Promise.resolve(JSON.parse(body)),
+        });
+    };
+
+    // virtual clock, so the 1s poll loop and the 5s running-flag reset fire in
+    // the right order without the tests actually waiting on them
+    let now = 0;
+    let seq = 0;
+    const timers = new Map();
+    win.setTimeout = (fn, ms = 0) => {
+        timers.set(++seq, { fn, due: now + ms, order: seq });
+        return seq;
+    };
+    win.clearTimeout = (id) => timers.delete(id);
+
+    async function advance(ms) {
+        const target = now + ms;
+        for (;;) {
+            const due = [...timers.entries()]
+                .filter(([, t]) => t.due <= target)
+                .sort((a, b) => a[1].due - b[1].due || a[1].order - b[1].order);
+            if (due.length === 0) break;
+            const [id, timer] = due[0];
+            timers.delete(id);
+            now = timer.due;
+            timer.fn();
+            await settle();
+        }
+        now = target;
+        await settle();
+    }
+
+    win.eval(scriptBlock(template));
+
+    return {
+        win,
+        doc,
+        calls,
+        advance,
+        settle,
+        el: (id) => doc.getElementById(id),
+        setFiles: (f) => {
+            files = f;
+        },
+        urls: (p) => calls.filter((c) => c.path === p).map((c) => c.url),
+        count: (p) => calls.filter((c) => c.path === p).length,
+    };
+}
+
+module.exports = { mount, scriptBlock, referencedIds, FIXTURES };


### PR DESCRIPTION
Follow-up to the continuous mode fix in aed2c63. That was a browser-side bug in code with no test coverage at all, so nothing caught it before it reached the telescope in the middle of an MMIRS night.

## What this adds

A small jsdom suite covering the control logic in `wfs.html` and `cwfs.html`, run by node's built-in test runner.

- `wfssrv/tests/js/harness.js` — mounts a template's control script in jsdom with a stubbed `fetch` and a virtual clock
- `wfssrv/tests/js/controls.test.js` — 12 tests
- `package.json` / `package-lock.json` — one devDependency, `jsdom`
- `.github/workflows/js-tests.yml` — runs `npm ci && npm test` on node 22 and 24
- `CLAUDE.md` — documents how to run the JS suite, plus a Deployment section recording that the summit installs from GitHub `master` (`pip install git+... --upgrade` into its `mmtwfs` conda env), so a fix is not deployed until it is pushed to `master`

## Design notes

**The javascript is read out of the templates, not copied.** The harness pulls the inline `<script>` block that defines `controlButtons` out of the `.html` file and evals it. A copy in the test tree would drift and quietly stop catching regressions.

**The DOM fixtures are hand-maintained, and guarded.** A test scrapes every `getElementById('...')` id out of each template's script block and asserts the fixture provides it, so a renamed or newly added control fails loudly instead of silently going untested.

**Timers run on a virtual clock.** The 1s poll loop and the 5s running-flag reset fire in the correct relative order without the tests waiting on them. The whole suite takes about half a second.

## Coverage

- continuous mode analyzes a new frame *while the controls are disabled* — this is the regression
- continuous mode applies focus/coma/M1 corrections when connected, and none when not
- continuous mode keeps polling but does not re-analyze the same frame
- continuous mode picks up each new frame as it arrives
- the MMIRS layout (no `#mode` selector) omits `mode=` from the analyze URL; a layout with one passes it through
- starting continuous backs the gains off to 0.2/0.5, and Turbo leaves them alone
- stopping continuous restores the gains, re-enables the controls, and halts the loop
- the cwfs Latest button loads the two newest frames and analyzes them

## Validation

Run against the pre-fix templates (`7bb3450`), **7 of the 12 fail**, including every continuous mode test. The 5 that pass are the ones that don't depend on the bug — gains, stop, cwfs Latest, and the two fixture guards. All 12 pass on current master, on node 22 and node 26.

## Scope

Node is only needed to run these tests. The served page still has no build step, `tox.ini` and the pixi config are untouched, and nothing here ships in the wheel. Browser-level behavior — bootstrap, mpl.js, websockets — remains uncovered; that would need Playwright and a much heavier CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
